### PR TITLE
[WIP] Add notebook fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Editor configs
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.pythonPath": "/Library/Frameworks/Python.framework/Versions/3.7/bin/python3",
+    "python.formatting.provider": "black"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.pythonPath": "/Library/Frameworks/Python.framework/Versions/3.7/bin/python3",
-    "python.formatting.provider": "black"
-}

--- a/testbook/__init__.py
+++ b/testbook/__init__.py
@@ -1,1 +1,2 @@
 from ._version import version as __version__
+from .execute import execute_cell

--- a/testbook/__init__.py
+++ b/testbook/__init__.py
@@ -1,2 +1,2 @@
 from ._version import version as __version__
-from .execute import execute_cell
+from .execute import notebook

--- a/testbook/client.py
+++ b/testbook/client.py
@@ -1,42 +1,50 @@
 from nbclient import NotebookClient
-from nbclient.exceptions import CellExecutionError
+from nbclient.client import CellExecutionError
 
 
 class TestbookNotebookClient(NotebookClient):
-    """
-    Module containing a  that executes the code cells
-    and updates outputs
-    """
+    def execute_cell(self, cell_index, execution_count=None, store_history=True):
+        if not isinstance(cell_index, list):
+            cell_index = [cell_index]
+        executed_cells = []
 
-    def execute(self, **kwargs):
+        for idx in cell_index:
+            cell = super().execute_cell(
+                self.nb['cells'][idx],
+                idx,
+                execution_count=execution_count,
+                store_history=store_history,
+            )
+            executed_cells.append(cell)
+
+        return executed_cells
+
+    def cell_output_text(self, cell_index):
+        """Return cell text output
+        
+        Arguments:
+            cell_index {int} -- cell index in notebook
+        
+        Returns:
+            str -- Text output
         """
-        Wraps the parent class process call slightly
+
+        text = ''
+        outputs = self.nb['cells'][cell_index]['outputs']
+        for output in outputs:
+            if 'text' in output:
+                text += output['text']
+
+        return text
+
+    def cell_output(self, cell_index):
+        """Return cell text output
+        
+        Arguments:
+            cell_index {int} -- cell index in notebook
+        
+        Returns:
+            list -- List of outputs for the given cell
         """
-        self.reset_execution_trackers()
 
-        with self.setup_kernel(**kwargs):
-            self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
-            self.testbook_execute_cells()
-            info_msg = self._wait_for_reply(self.kc.kernel_info())
-            self.nb.metadata['language_info'] = info_msg['content']['language_info']
-            self.set_widgets_metadata()
-
-        return self.nb
-
-    def testbook_execute_cell(
-        self, cell, cell_index, execution_count=None, store_history=True, **kwargs
-    ):
-        """
-        Wraps the parent class process call slightly
-        """
-        self.reset_execution_trackers()
-
-        with self.setup_kernel(**kwargs):
-            self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
-            self.execute_cell(cell, cell_index, execution_count, store_history)
-            info_msg = self._wait_for_reply(self.kc.kernel_info())
-            self.nb.metadata['language_info'] = info_msg['content']['language_info']
-            self.set_widgets_metadata()
-
-        return self.nb
-
+        outputs = self.nb['cells'][cell_index]['outputs']

--- a/testbook/client.py
+++ b/testbook/client.py
@@ -1,0 +1,53 @@
+from nbclient import NotebookClient
+from nbclient.exceptions import CellExecutionError
+
+
+class TestbookNotebookClient(NotebookClient):
+    """
+    Module containing a  that executes the code cells
+    and updates outputs
+    """
+
+    def __init__(self, nb, km=None, **kw):
+        """Initializes the execution manager.
+        Parameters
+        ----------
+        nb : Notebook
+        km : KernerlManager (optional)
+            Optional kernel manager. If none is provided, a kernel manager will
+            be created.
+        """
+        super().__init__(nb, km=km, **kw)
+
+    def execute(self, **kwargs):
+        """
+        Wraps the parent class process call slightly
+        """
+        self.reset_execution_trackers()
+
+        with self.setup_kernel(**kwargs):
+            self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
+            self.testbook_execute_cells()
+            info_msg = self._wait_for_reply(self.kc.kernel_info())
+            self.nb.metadata['language_info'] = info_msg['content']['language_info']
+            self.set_widgets_metadata()
+
+        return self.nb
+
+    def testbook_execute_cell(
+        self, cell, cell_index, execution_count=None, store_history=True, **kwargs
+    ):
+        """
+        Wraps the parent class process call slightly
+        """
+        self.reset_execution_trackers()
+
+        with self.setup_kernel(**kwargs):
+            self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
+            self.execute_cell(cell, cell_index, execution_count, store_history)
+            info_msg = self._wait_for_reply(self.kc.kernel_info())
+            self.nb.metadata['language_info'] = info_msg['content']['language_info']
+            self.set_widgets_metadata()
+
+        return self.nb
+

--- a/testbook/client.py
+++ b/testbook/client.py
@@ -8,17 +8,6 @@ class TestbookNotebookClient(NotebookClient):
     and updates outputs
     """
 
-    def __init__(self, nb, km=None, **kw):
-        """Initializes the execution manager.
-        Parameters
-        ----------
-        nb : Notebook
-        km : KernerlManager (optional)
-            Optional kernel manager. If none is provided, a kernel manager will
-            be created.
-        """
-        super().__init__(nb, km=km, **kw)
-
     def execute(self, **kwargs):
         """
         Wraps the parent class process call slightly

--- a/testbook/execute.py
+++ b/testbook/execute.py
@@ -1,0 +1,21 @@
+import pytest
+import nbformat
+from testbook.testbook.client import TestbookNotebookClient
+
+
+def execute_cell(notebook_filename, cell_index):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            with open(notebook_filename) as f:
+                nb = nbformat.read(f, as_version=4)
+
+            client = TestbookNotebookClient(nb)
+            nb_executed = client.testbook_execute_cell(
+                cell=nb['cells'][cell_index], cell_index=cell_index
+            )
+
+            func(nb_executed['cells'][cell_index], *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/testbook/execute.py
+++ b/testbook/execute.py
@@ -1,24 +1,20 @@
-from functools import wraps
+from contextlib import contextmanager
 
 import nbformat
+import pytest
 
 from testbook.client import TestbookNotebookClient
 
 
-def execute_cell(notebook_filename, cell_index):
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            with open(notebook_filename) as f:
-                nb = nbformat.read(f, as_version=4)
+@pytest.fixture
+def notebook():
+    @contextmanager
+    def notebook_loader(nb_path, **kwargs):
+        with open(nb_path) as f:
+            nb = nbformat.read(f, as_version=4)
 
-            client = TestbookNotebookClient(nb)
-            nb_executed = client.testbook_execute_cell(
-                cell=nb['cells'][cell_index], cell_index=cell_index
-            )
+        client = TestbookNotebookClient(nb)
+        with client.setup_kernel(**kwargs):
+            yield client
 
-            func(nb_executed['cells'][cell_index], *args, **kwargs)
-
-        return wrapper
-
-    return decorator
+    return notebook_loader

--- a/testbook/execute.py
+++ b/testbook/execute.py
@@ -1,10 +1,13 @@
-import pytest
+from functools import wraps
+
 import nbformat
-from testbook.testbook.client import TestbookNotebookClient
+
+from testbook.client import TestbookNotebookClient
 
 
 def execute_cell(notebook_filename, cell_index):
     def decorator(func):
+        @wraps(func)
         def wrapper(*args, **kwargs):
             with open(notebook_filename) as f:
                 nb = nbformat.read(f, as_version=4)

--- a/testbook/tests/resources/foo.ipynb
+++ b/testbook/tests/resources/foo.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "1 + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('hello world')\n",
+    "\n",
+    "print([1, 2, 3])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/testbook/tests/resources/foo.ipynb
+++ b/testbook/tests/resources/foo.ipynb
@@ -19,6 +19,25 @@
     "\n",
     "print([1, 2, 3])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def foo():\n",
+    "    print('foo')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "foo()"
+   ]
   }
  ],
  "metadata": {

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -6,5 +6,7 @@ from testbook import notebook
 def test_notebook(notebook):
     with notebook('testbook/tests/resources/foo.ipynb') as nb:
         nb.execute_cell(1)
-
         assert nb.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'
+
+        nb.execute_cell([2, 3])
+        assert nb.cell_output_text(3) == 'foo\n'

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -1,0 +1,10 @@
+import pytest
+
+from testbook import notebook
+
+
+def test_notebook(notebook):
+    with notebook('testbook/tests/resources/foo.ipynb') as nb:
+        nb.execute_cell(1)
+
+        assert nb.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'


### PR DESCRIPTION
Ref #5 

Created a `execute_cell` decorator that can be used as follows:

```python
 from testbook import execute_cell

 @execute_cell('path/to/notebook.ipynb', 3)
 def test_foo(executed_cell):
     pass
```
As of now, it just returns the `dict` containing the executed cell. I will extend this to be a wrapper object on which we can perform test assertions. 

cc @MSeal 

EDIT: https://github.com/nteract/testbook/pull/10#issuecomment-604007498