### PR TITLE
Implemented code injection

### DIFF
--- a/testbook/__init__.py
+++ b/testbook/__init__.py
@@ -1,2 +1,2 @@
 from ._version import version as __version__
-from .execute import notebook
+from .execute import notebook_loader

--- a/testbook/client.py
+++ b/testbook/client.py
@@ -1,5 +1,12 @@
+import inspect
+import json
+import textwrap
+
+from nbformat.v4 import new_code_cell
+
 from nbclient import NotebookClient
 from nbclient.client import CellExecutionError
+from testbook.testbooknode import TestbookNode
 
 
 class TestbookNotebookClient(NotebookClient):
@@ -17,7 +24,7 @@ class TestbookNotebookClient(NotebookClient):
             )
             executed_cells.append(cell)
 
-        return executed_cells
+        return executed_cells[0] if len(executed_cells) == 1 else executed_cells
 
     def cell_output_text(self, cell_index):
         """Return cell text output
@@ -48,3 +55,35 @@ class TestbookNotebookClient(NotebookClient):
         """
 
         outputs = self.nb['cells'][cell_index]['outputs']
+
+    def inject(self, func, args=None):
+        """Injects given function and executes with arguments passed
+        
+        Arguments:
+            func {__func__} -- function name
+            args {list} -- list of arguments to be passed
+        
+        Returns:
+            TestbookNode -- dict containing function and function call along with outputs
+        """
+
+        lines = inspect.getsource(func)
+        args_str = ', '.join(map(json.dumps, args)) if args else ''
+
+        # Add the function call to the same cell
+        lines += textwrap.dedent(
+            f"""
+            # Calling {func.__name__} 
+            {func.__name__}({args_str})
+        """
+        )
+
+
+        # Create a code cell
+        inject_cell = new_code_cell(lines)
+
+        # Insert it into the in memory notebook object and execute it
+        self.nb.cells.append(inject_cell)
+        cell = self.execute_cell(len(self.nb.cells) - 1)
+
+        return TestbookNode(cell)

--- a/testbook/execute.py
+++ b/testbook/execute.py
@@ -7,9 +7,9 @@ from testbook.client import TestbookNotebookClient
 
 
 @pytest.fixture
-def notebook():
+def notebook_loader():
     @contextmanager
-    def notebook_loader(nb_path, **kwargs):
+    def notebook_helper(nb_path, **kwargs):
         with open(nb_path) as f:
             nb = nbformat.read(f, as_version=4)
 
@@ -17,4 +17,4 @@ def notebook():
         with client.setup_kernel(**kwargs):
             yield client
 
-    return notebook_loader
+    return notebook_helper

--- a/testbook/testbooknode.py
+++ b/testbook/testbooknode.py
@@ -1,0 +1,18 @@
+from nbformat import NotebookNode
+
+
+class TestbookNode(NotebookNode):
+    """
+    Extends `NodebookNode` to perform assertions
+    """
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+
+    def assert_output_text(self, expected_text):
+        text = ''
+        for output in self['outputs']:
+            if 'text' in output:
+                text += output['text']
+
+        assert text.strip() == expected_text.strip()

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -1,12 +1,12 @@
 import pytest
 
-from testbook import notebook
+from testbook import notebook_loader
 
 
-def test_notebook(notebook):
-    with notebook('testbook/tests/resources/foo.ipynb') as nb:
-        nb.execute_cell(1)
-        assert nb.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'
+def test_notebook(notebook_loader):
+    with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
+        notebook.execute_cell(1)
+        assert notebook.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'
 
-        nb.execute_cell([2, 3])
-        assert nb.cell_output_text(3) == 'foo\n'
+        notebook.execute_cell([2, 3])
+        assert notebook.cell_output_text(3) == 'foo\n'

--- a/testbook/tests/test_inject.py
+++ b/testbook/tests/test_inject.py
@@ -1,0 +1,27 @@
+import pytest
+
+from testbook import notebook_loader
+
+
+def helper_1():
+    print("I ran in the kernel")
+
+
+def helper_2(arg1, arg2):
+    print(f"You passed {arg1} and {arg2}")
+
+
+@pytest.mark.parametrize(
+    "helper_func, args, expected_text",
+    [
+        (helper_1, None, "I ran in the kernel"),
+        (helper_2, [1, 2], "You passed 1 and 2"),
+        (helper_2, ['a', 'b'], "You passed a and b"),
+        (helper_2, [[1, 2], 'b'], "You passed [1, 2] and b"),
+        (helper_2, [{'key1': 'value1'}, {'key2': 'value2'}], "You passed {'key1': 'value1'} and {'key2': 'value2'}"),
+    ],
+)
+def test_inject(helper_func, args, expected_text, notebook_loader):
+
+    with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
+        notebook.inject(helper_func, args).assert_output_text(expected_text)

--- a/testbook/tests/test_inject.py
+++ b/testbook/tests/test_inject.py
@@ -18,10 +18,50 @@ def helper_2(arg1, arg2):
         (helper_2, [1, 2], "You passed 1 and 2"),
         (helper_2, ['a', 'b'], "You passed a and b"),
         (helper_2, [[1, 2], 'b'], "You passed [1, 2] and b"),
-        (helper_2, [{'key1': 'value1'}, {'key2': 'value2'}], "You passed {'key1': 'value1'} and {'key2': 'value2'}"),
+        (
+            helper_2,
+            [{'key1': 'value1'}, {'key2': 'value2'}],
+            "You passed {'key1': 'value1'} and {'key2': 'value2'}",
+        ),
     ],
 )
 def test_inject(helper_func, args, expected_text, notebook_loader):
 
     with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
         notebook.inject(helper_func, args).assert_output_text(expected_text)
+
+
+@pytest.mark.parametrize(
+    "code_block, expected_text",
+    [
+        (
+            '''
+            def foo():
+                print('I ran in the code block')
+            foo()
+        ''',
+            "I ran in the code block",
+        ),
+        (
+            '''
+            def foo(arg):
+                print(f'You passed {arg}')
+            foo('bar')
+        ''',
+            "You passed bar",
+        ),
+    ],
+)
+def test_inject_code_block(code_block, expected_text, notebook_loader):
+    with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
+        notebook.inject(code_block).assert_output_text(expected_text)
+
+
+def test_inject_raises_exception(notebook_loader):
+    with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
+
+        values = [3, {'key': 'value'}, ['a', 'b', 'c'], (1, 2, 3), {1, 2, 3}]
+
+        for value in values:
+            with pytest.raises(TypeError):
+                notebook.inject(value)


### PR DESCRIPTION
Implements #11 

- Created a basic implementation of code injection. 
- renamed `notebook` fixture to `notebook_loader`

It works as follows:
```python
from testbook import notebook_loader

def foo():
   print('I ran in foo')

def test_foo():
   with notebook_loader('/path/to/notebook') as notebook:
      notebook.inject(foo).assert_output_text('I ran in foo')
```

And a function can be injected when called with arguments as well,
```python
from testbook import notebook_loader

def foo_with_args(arg1, arg2):
   print(f'You passed {arg1} and {arg2}')

def test_foo_with_args():
   with notebook_loader('/path/to/notebook') as notebook:
      notebook.inject(foo_with_args, ['value1', 'value2']).assert_output_text('You passed value1 and value2')
```

cc @MSeal 