### PR TITLE
Implemented decorator pattern with `notebook_loader`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # Editor configs
 .vscode/
+.idea/

--- a/testbook/__init__.py
+++ b/testbook/__init__.py
@@ -1,2 +1,2 @@
 from ._version import version as __version__
-from .execute import notebook_loader
+from .execute import notebook_loader, notebook

--- a/testbook/__init__.py
+++ b/testbook/__init__.py
@@ -1,2 +1,2 @@
 from ._version import version as __version__
-from .execute import notebook_loader, notebook
+from .execute import notebook_loader

--- a/testbook/exceptions.py
+++ b/testbook/exceptions.py
@@ -1,3 +1,4 @@
 class CellTagNotFoundError(Exception):
     """Raised when cell tag is not declared in notebook"""
+
     pass

--- a/testbook/execute.py
+++ b/testbook/execute.py
@@ -9,12 +9,37 @@ from testbook.client import TestbookNotebookClient
 @pytest.fixture
 def notebook_loader():
     @contextmanager
-    def notebook_helper(nb_path, **kwargs):
+    def notebook_helper(nb_path, prerun=None, **kwargs):
         with open(nb_path) as f:
             nb = nbformat.read(f, as_version=4)
 
         client = TestbookNotebookClient(nb)
         with client.setup_kernel(**kwargs):
+            if prerun is not None:
+                client.execute_cell(prerun)
+
             yield client
 
     return notebook_helper
+
+
+def notebook(nb_path, prerun=None, **kwargs):
+    def wrapper(func):
+        with open(nb_path) as f:
+            nb = nbformat.read(f, as_version=4)
+
+        client = TestbookNotebookClient(nb)
+
+        def inner(*args, **kwargs):
+            with client.setup_kernel(**kwargs):
+                if prerun is not None:
+                    client.execute_cell(prerun)
+
+                return func(client, *args, **kwargs)
+
+        inner.__name__ = func.__name__
+        inner.__doc__ = func.__doc__
+
+        return inner
+
+    return wrapper

--- a/testbook/execute.py
+++ b/testbook/execute.py
@@ -6,21 +6,17 @@ import pytest
 from testbook.client import TestbookNotebookClient
 
 
-@pytest.fixture
-def notebook_loader():
-    @contextmanager
-    def notebook_helper(nb_path, prerun=None, **kwargs):
-        with open(nb_path) as f:
-            nb = nbformat.read(f, as_version=4)
+@contextmanager
+def notebook_loader(nb_path, prerun=None, **kwargs):
+    with open(nb_path) as f:
+        nb = nbformat.read(f, as_version=4)
 
-        client = TestbookNotebookClient(nb)
-        with client.setup_kernel(**kwargs):
-            if prerun is not None:
-                client.execute_cell(prerun)
+    client = TestbookNotebookClient(nb)
+    with client.setup_kernel(**kwargs):
+        if prerun is not None:
+            client.execute_cell(prerun)
 
-            yield client
-
-    return notebook_helper
+        yield client
 
 
 def notebook(nb_path, prerun=None, **kwargs):

--- a/testbook/execute.py
+++ b/testbook/execute.py
@@ -41,4 +41,7 @@ class notebook_loader:
             with self.client.setup_kernel():
                 func(self.client, *args, **kwargs)
 
+        wrapper.__name__ = func.__name__
+        wrapper.__doc__ = func.__doc__
+
         return wrapper

--- a/testbook/execute.py
+++ b/testbook/execute.py
@@ -37,17 +37,8 @@ class notebook_loader:
         self.client._cleanup_kernel()
 
     def __call__(self, func):
-        def wrapper():
-            self._start_kernel()
-
-            def inner(*args, **kwargs):
-                return func(self.client, *args, **kwargs)
-
-            self.client._cleanup_kernel()
-
-            inner.__name__ = func.__name__
-            inner.__doc__ = func.__doc__
-
-            return inner
+        def wrapper(*args, **kwargs):
+            with self.client.setup_kernel():
+                func(self.client, *args, **kwargs)
 
         return wrapper

--- a/testbook/testbooknode.py
+++ b/testbook/testbooknode.py
@@ -3,7 +3,7 @@ from nbformat import NotebookNode
 
 class TestbookNode(NotebookNode):
     """
-    Extends `NodebookNode` to perform assertions
+    Extends `NotebookNode` to perform assertions
     """
 
     def __init__(self, *args, **kw):

--- a/testbook/tests/test_client.py
+++ b/testbook/tests/test_client.py
@@ -5,7 +5,7 @@ from testbook.exceptions import CellTagNotFoundError
 
 
 @pytest.mark.parametrize("get_call_index_args, expected_result", [(2, 2), ('hello', 1)])
-def test_get_cell_index(get_call_index_args, expected_result, notebook_loader):
+def test_get_cell_index(get_call_index_args, expected_result):
     with notebook_loader('testbook/tests/resources/inject.ipynb') as notebook:
         assert notebook._get_cell_index(get_call_index_args) == expected_result
 
@@ -14,7 +14,7 @@ def test_get_cell_index(get_call_index_args, expected_result, notebook_loader):
     "get_call_index_args, expected_error",
     [([1, 2, 3], TypeError), ('non-existent-tag', CellTagNotFoundError)],
 )
-def test_get_cell_index_raises_error(get_call_index_args, expected_error, notebook_loader):
+def test_get_cell_index_raises_error(get_call_index_args, expected_error):
     with notebook_loader('testbook/tests/resources/inject.ipynb') as notebook:
         with pytest.raises(expected_error):
             notebook._get_cell_index(get_call_index_args)

--- a/testbook/tests/test_client.py
+++ b/testbook/tests/test_client.py
@@ -3,7 +3,7 @@ import pytest
 from testbook import notebook_loader
 
 
-def test_get_cell_index(notebook_loader):
+def test_get_cell_index():
     with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
         with pytest.raises(TypeError):
             notebook._get_cell_index(1)

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -1,4 +1,4 @@
-from testbook import notebook_loader, notebook
+from testbook import notebook_loader
 
 
 def test_execute_cell():
@@ -19,7 +19,7 @@ def test_execute_cell_tags():
         assert notebook.cell_output_text('execute_foo') == 'foo\n'
 
 
-@notebook("testbook/tests/resources/foo.ipynb")
+@notebook_loader("testbook/tests/resources/foo.ipynb")
 def test_notebook(notebook):
     notebook.execute_cell('test1')
     assert notebook.cell_output_text('test1') == 'hello world\n[1, 2, 3]\n'
@@ -28,6 +28,6 @@ def test_notebook(notebook):
     assert notebook.cell_output_text('execute_foo') == 'foo\n'
 
 
-@notebook("testbook/tests/resources/foo.ipynb", prerun='test1')
+@notebook_loader("testbook/tests/resources/foo.ipynb", prerun='test1')
 def test_notebook_with_prerun(notebook):
     assert notebook.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -30,5 +30,4 @@ def test_notebook(notebook):
 
 @notebook_loader("testbook/tests/resources/foo.ipynb", prerun='test1')
 def test_notebook_with_prerun(notebook):
-    print(notebook.cell_output_text(1))
     assert notebook.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -30,4 +30,5 @@ def test_notebook(notebook):
 
 @notebook_loader("testbook/tests/resources/foo.ipynb", prerun='test1')
 def test_notebook_with_prerun(notebook):
+    print(notebook.cell_output_text(1))
     assert notebook.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -1,4 +1,4 @@
-from testbook import notebook_loader
+from testbook import notebook_loader, notebook
 
 
 def test_execute_cell(notebook_loader):
@@ -17,3 +17,17 @@ def test_execute_cell_tags(notebook_loader):
 
         notebook.execute_cell(['prepare_foo', 'execute_foo'])
         assert notebook.cell_output_text('execute_foo') == 'foo\n'
+
+
+@notebook("testbook/tests/resources/foo.ipynb")
+def test_notebook(notebook):
+    notebook.execute_cell('test1')
+    assert notebook.cell_output_text('test1') == 'hello world\n[1, 2, 3]\n'
+
+    notebook.execute_cell(['prepare_foo', 'execute_foo'])
+    assert notebook.cell_output_text('execute_foo') == 'foo\n'
+
+
+@notebook("testbook/tests/resources/foo.ipynb", prerun='test1')
+def test_notebook_with_prerun(notebook):
+    assert notebook.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -1,7 +1,7 @@
 from testbook import notebook_loader, notebook
 
 
-def test_execute_cell(notebook_loader):
+def test_execute_cell():
     with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
         notebook.execute_cell(1)
         assert notebook.cell_output_text(1) == 'hello world\n[1, 2, 3]\n'
@@ -10,7 +10,7 @@ def test_execute_cell(notebook_loader):
         assert notebook.cell_output_text(3) == 'foo\n'
 
 
-def test_execute_cell_tags(notebook_loader):
+def test_execute_cell_tags():
     with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
         notebook.execute_cell('test1')
         assert notebook.cell_output_text('test1') == 'hello world\n[1, 2, 3]\n'

--- a/testbook/tests/test_inject.py
+++ b/testbook/tests/test_inject.py
@@ -95,6 +95,6 @@ def test_inject_raises_exception():
         ),
     ],
 )
-def test_inject_with_prerun(prerun, code_block, expected_text, notebook_loader):
+def test_inject_with_prerun(prerun, code_block, expected_text):
     with notebook_loader('testbook/tests/resources/inject.ipynb') as notebook:
         assert notebook.inject(code_block, prerun=prerun).output_text == expected_text

--- a/testbook/tests/test_inject.py
+++ b/testbook/tests/test_inject.py
@@ -25,7 +25,7 @@ def helper_2(arg1, arg2):
         ),
     ],
 )
-def test_inject(helper_func, args, expected_text, notebook_loader):
+def test_inject(helper_func, args, expected_text):
 
     with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
         notebook.inject(helper_func, args).assert_output_text(expected_text)
@@ -52,12 +52,12 @@ def test_inject(helper_func, args, expected_text, notebook_loader):
         ),
     ],
 )
-def test_inject_code_block(code_block, expected_text, notebook_loader):
+def test_inject_code_block(code_block, expected_text):
     with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
         notebook.inject(code_block).assert_output_text(expected_text)
 
 
-def test_inject_raises_exception(notebook_loader):
+def test_inject_raises_exception():
     with notebook_loader('testbook/tests/resources/foo.ipynb') as notebook:
 
         values = [3, {'key': 'value'}, ['a', 'b', 'c'], (1, 2, 3), {1, 2, 3}]


### PR DESCRIPTION
Implements #5 

1. Created a class called `notebook_loader` which encapsulates the contextmanager and decorator pattern of setting up tests. 

- **contextmanager pattern**:
```python
from testbook import notebook_loader

def test_foo():
    with notebook_loader('/path/to/notebook.ipynb', prerun=[0, 1]) as notebook:
        notebook.execute(['test1', 'test2'])
        assert notebook.cell_output_text('test2') == 'foobar'
```

- **decorator pattern**:
```python
from testbook import notebook_loader

@notebook_loader('/path/to/notebook.ipynb', prerun=[0, 1])
def test_foo(notebook):
    notebook.execute(['test1', 'test2'])
    assert notebook.cell_output_text('test2') == 'foobar'
```

2. Added `prerun` argument to `notebook_loader`