### PR TITLE
Raise `TestbookError` with minimal traceback

### DIFF
--- a/testbook/client.py
+++ b/testbook/client.py
@@ -4,10 +4,11 @@ from inspect import getsource
 from textwrap import dedent
 
 from nbclient import NotebookClient
+from nbclient.exceptions import CellExecutionError
 from nbformat.v4 import new_code_cell
 
-from testbook.exceptions import TestbookError, TestbookCellTagNotFoundError
-from testbook.testbooknode import TestbookNode
+from .exceptions import TestbookCellTagNotFoundError, TestbookError
+from .testbooknode import TestbookNode
 
 
 class TestbookNotebookClient(NotebookClient):
@@ -60,7 +61,7 @@ class TestbookNotebookClient(NotebookClient):
         for idx in cell_indexes:
             try:
                 cell = super().execute_cell(self.nb['cells'][idx], idx, **kwargs)
-            except Exception as e:
+            except CellExecutionError as e:
                 raise TestbookError(str(e)) from None
 
             executed_cells.append(cell)

--- a/testbook/client.py
+++ b/testbook/client.py
@@ -58,7 +58,11 @@ class TestbookNotebookClient(NotebookClient):
 
         executed_cells = []
         for idx in cell_indexes:
-            cell = super().execute_cell(self.nb['cells'][idx], idx, **kwargs)
+            try:
+                cell = super().execute_cell(self.nb['cells'][idx], idx, **kwargs)
+            except Exception as e:
+                raise TestbookError(str(e)) from None
+
             executed_cells.append(cell)
 
         return executed_cells[0] if len(executed_cells) == 1 else executed_cells
@@ -128,12 +132,10 @@ class TestbookNotebookClient(NotebookClient):
 
     def value(self, name):
         """Extract a JSON-able variable value from notebook kernel"""
-        try:
-            result = self.inject(name)
-            if not self._execute_result(result.outputs):
-                raise Exception('code provided does not produce execute_result')
-        except Exception as e:
-            raise TestbookError(str(e)) from None
+
+        result = self.inject(name)
+        if not self._execute_result(result.outputs):
+            raise TestbookError('code provided does not produce execute_result')
 
         code = """
         from IPython.display import JSON

--- a/testbook/exceptions.py
+++ b/testbook/exceptions.py
@@ -1,4 +1,8 @@
-class CellTagNotFoundError(Exception):
+class TestbookError(Exception):
+    pass
+
+
+class TestbookCellTagNotFoundError(TestbookError):
     """Raised when cell tag is not declared in notebook"""
 
     pass

--- a/testbook/testbook.py
+++ b/testbook/testbook.py
@@ -1,6 +1,6 @@
 import nbformat
 
-from testbook.client import TestbookNotebookClient
+from .client import TestbookNotebookClient
 
 
 class testbook:

--- a/testbook/tests/resources/foo.ipynb
+++ b/testbook/tests/resources/foo.ipynb
@@ -54,9 +54,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "error_cell"
+    ]
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "# Will raise ZeroDivisionError\n",
+    "1/0"
+   ]
   }
  ],
  "metadata": {
@@ -76,7 +83,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/testbook/tests/test_client.py
+++ b/testbook/tests/test_client.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..testbook import testbook
-from ..exceptions import CellTagNotFoundError
+from ..exceptions import TestbookCellTagNotFoundError, TestbookError
 
 
 @pytest.mark.parametrize("cell_index_args, expected_result", [(2, 2), ('hello', 1)])
@@ -12,7 +12,7 @@ def test_cell_index(cell_index_args, expected_result):
 
 @pytest.mark.parametrize(
     "cell_index_args, expected_error",
-    [([1, 2, 3], TypeError), ('non-existent-tag', CellTagNotFoundError)],
+    [([1, 2, 3], TypeError), ('non-existent-tag', TestbookCellTagNotFoundError)],
 )
 def test_cell_index_raises_error(cell_index_args, expected_error):
     with testbook('testbook/tests/resources/inject.ipynb') as notebook:
@@ -42,5 +42,5 @@ def test_value(cell_tag, var_name, expected_result):
 )
 def test_value_raises_error(cell_tag, code):
     with testbook('testbook/tests/resources/inject.ipynb', prerun=cell_tag) as notebook:
-        with pytest.raises(ValueError):
+        with pytest.raises(TestbookError):
             notebook.value(code)

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -1,31 +1,31 @@
+import pytest
+
 from ..testbook import testbook
+from ..exceptions import TestbookError
 
 
-def test_execute_cell():
-    with testbook('testbook/tests/resources/foo.ipynb') as notebook:
-        notebook.execute_cell(1)
-        assert notebook.cell_output_text(1) == 'hello world\n[1, 2, 3]'
+@testbook('testbook/tests/resources/foo.ipynb')
+def test_execute_cell(notebook):
+    notebook.execute_cell(1)
+    assert notebook.cell_output_text(1) == 'hello world\n[1, 2, 3]'
 
-        notebook.execute_cell([2, 3])
-        assert notebook.cell_output_text(3) == 'foo'
-
-
-def test_execute_cell_tags():
-    with testbook('testbook/tests/resources/foo.ipynb') as notebook:
-        notebook.execute_cell('test1')
-        assert notebook.cell_output_text('test1') == 'hello world\n[1, 2, 3]'
-
-        notebook.execute_cell(['prepare_foo', 'execute_foo'])
-        assert notebook.cell_output_text('execute_foo') == 'foo'
+    notebook.execute_cell([2, 3])
+    assert notebook.cell_output_text(3) == 'foo'
 
 
-@testbook("testbook/tests/resources/foo.ipynb")
-def test_testbook(notebook):
+@testbook('testbook/tests/resources/foo.ipynb')
+def test_execute_cell_tags(notebook):
     notebook.execute_cell('test1')
     assert notebook.cell_output_text('test1') == 'hello world\n[1, 2, 3]'
 
     notebook.execute_cell(['prepare_foo', 'execute_foo'])
     assert notebook.cell_output_text('execute_foo') == 'foo'
+
+
+@testbook('testbook/tests/resources/foo.ipynb')
+def test_execute_cell_raises_error(notebook):
+    with pytest.raises(TestbookError):
+        notebook.execute_cell('error_cell')
 
 
 @testbook("testbook/tests/resources/foo.ipynb", prerun='prepare_foo')


### PR DESCRIPTION
Fixes part of #32 

The part that involves stdout and stderr containing same line of error needs to be handled in nbclient. 