### PR TITLE
Change package name to nteract-testbook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ doc_reqs = read_reqs(os.path.join(os.path.dirname(__file__), 'docs/requirements-
 extras_require = {"test": dev_reqs, "dev": dev_reqs, "sphinx": doc_reqs}
 
 setup(
-    name='testbook',
+    name='nteract-testbook',
     version=version(),
-    description='TODO',
+    description='A unit testing framework for Jupyter Notebooks',
     author='nteract contributors',
     author_email='nteract@googlegroups.com',
     license='BSD',

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,8 @@ skip_install = true
 # Have to use /bin/bash or the `*` will cause that argument to get quoted by the tox command line...
 commands =
     python setup.py sdist --dist-dir={distdir} bdist_wheel --dist-dir={distdir}
-    /bin/bash -c 'python -m pip install -U --force-reinstall {distdir}/testbook*.whl'
-    /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/testbook*.tar.gz'
+    /bin/bash -c 'python -m pip install -U --force-reinstall {distdir}/nteract*testbook*.whl'
+    /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nteract*testbook*.tar.gz'
 
 # Black
 [testenv:black]


### PR DESCRIPTION
We'll need to have the package name as `nteract-testbook` instead of just `testbook` due to a PyPI name conflict with [this](https://github.com/bkief/testbook) project. 