### PR TITLE
Updated docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://github.com/nteract/testbook/workflows/CI/badge.svg)](https://github.com/nteract/testbook/actions)
 [![image](https://codecov.io/github/nteract/testbook/coverage.svg?branch=master)](https://codecov.io/github/nteract/testbook?branch=master)
-[![Documentation Status](https://readthedocs.org/projects/test-book/badge/?version=latest)](https://test-book.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/testbook/badge/?version=latest)](https://testbook.readthedocs.io/en/latest/?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/testbook.svg)](https://pypi.org/project/testbook/)
 [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
 [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
@@ -48,7 +48,7 @@ pip install testbook
 
 ## Documentation
 
-See [readthedocs](https://test-book.readthedocs.io/en/latest/) for more in-depth details.
+See [readthedocs](https://testbook.readthedocs.io/en/latest/) for more in-depth details.
 
 ## Development Guide
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ changelog.md
 [github-ci-link]: https://github.com/nteract/testbook/actions
 [github-link]: https://github.com/nteract/testbook
 [rtd-badge]: https://readthedocs.org/projects/testbook/badge/?version=latest
-[rtd-link]: https://test-book.readthedocs.io/en/latest/?badge=latest
+[rtd-link]: https://testbook.readthedocs.io/en/latest/?badge=latest
 [codecov-badge]: https://codecov.io/gh/nteract/testbook/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/nteract/testbook
 [github-badge]: https://img.shields.io/github/stars/nteract/testbook?label=github

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires=requirements,
     extras_require=extras_require,
     project_urls={
-        'Documentation': 'https://test-book.readthedocs.io',
+        'Documentation': 'https://testbook.readthedocs.io',
         'Funding': 'https://nteract.io',
         'Source': 'https://github.com/nteract/testbook/',
         'Tracker': 'https://github.com/nteract/testbook/issues',


### PR DESCRIPTION
Updated docs link to testbook.readthedocs.io instead of test-book.readthedocs.io 
 