### PR TITLE
Added kernel kwarg

### DIFF
--- a/testbook/testbook.py
+++ b/testbook/testbook.py
@@ -4,12 +4,13 @@ from .client import TestbookNotebookClient
 
 
 class testbook:
-    def __init__(self, nb, execute=None, timeout=60, allow_errors=False):
+    def __init__(self, nb, execute=None, timeout=60, kernel_name='python3', allow_errors=False):
         self.execute = execute
         self.client = TestbookNotebookClient(
             nbformat.read(nb, as_version=4) if not isinstance(nb, nbformat.NotebookNode) else nb,
             timeout=timeout,
-            allow_errors=allow_errors
+            allow_errors=allow_errors,
+            kernel_name=kernel_name
         )
 
     def _prepare(self):


### PR DESCRIPTION
Added `kernel_name` kwarg.

You can now pass in custom kernel names, differing from the one specified in the metadata of the notebook.

```python
from testbook import testbook

with testbook('notebook.ipynb', kernel_name='my_python_kernel', execute=True) as tb:
    pass
```
