### PR TITLE
Using as decorator is a pytest fixture

### DIFF
--- a/testbook/testbook.py
+++ b/testbook/testbook.py
@@ -1,5 +1,11 @@
 import nbformat
 
+try:
+    from pytest import fixture
+except ImportError:
+    def fixture(func, *args, **kwargs):
+        return func
+
 from .client import TestbookNotebookClient
 
 
@@ -36,4 +42,4 @@ class testbook:
         wrapper.__name__ = func.__name__
         wrapper.__doc__ = func.__doc__
 
-        return wrapper
+        return fixture(wrapper)

--- a/testbook/testbook.py
+++ b/testbook/testbook.py
@@ -2,7 +2,7 @@ import nbformat
 
 try:
     from pytest import fixture
-except ImportError:
+except ImportError:  # pragma: no cover
     def fixture(func, *args, **kwargs):
         return func
 
@@ -34,7 +34,7 @@ class testbook:
         self.client._cleanup_kernel()
 
     def __call__(self, func):
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs):  # pragma: no cover
             with self.client.setup_kernel():
                 self._prepare()
                 func(self.client, *args, **kwargs)

--- a/testbook/tests/test_testbook.py
+++ b/testbook/tests/test_testbook.py
@@ -1,4 +1,7 @@
 import nbformat
+
+import pytest
+
 from ..testbook import testbook
 
 
@@ -16,6 +19,17 @@ def test_testbook_class_decorator(tb):
 @testbook('testbook/tests/resources/inject.ipynb')
 def test_testbook_class_decorator_execute_none(tb):
     assert tb.code_cells_executed == 0
+
+
+@testbook('testbook/tests/resources/inject.ipynb', execute=True)
+def test_testbook_decorator_with_fixture(nb, tmp_path):
+    assert True  # Check that the decorator accept to be passed along side a fixture
+
+
+@testbook('testbook/tests/resources/inject.ipynb', execute=True)
+@pytest.mark.parametrize("cell_index_args, expected_result", [(2, 2), ('hello', 1)])
+def test_testbook_decorator_with_markers(nb, cell_index_args, expected_result):
+    assert nb._cell_index(cell_index_args) == expected_result
 
 
 def test_testbook_execute_all_cells_context_manager():


### PR DESCRIPTION
The current decorator implementation does not return a pytest fixture. Therefore it is quite surprising to fail when using pytest fixture or marker (in particular parametrize).

The first commit of this PR proves that the current code is failing. And the second proposed a correction for it.

`pytest.fixture` is patch in case `pytest` is not importable to ensure this package stays independent of the unit test framework.