### PR TITLE
Fix decorator in usage.md

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -18,7 +18,7 @@ These patterns are interchangeable in most cases. If there are nested decorators
 
    from testbook import testbook
 
-   @testbook.testbook('/path/to/notebook.ipynb', execute=True)
+   @testbook('/path/to/notebook.ipynb', execute=True)
    def test_func(tb):
        func = tb.ref("func")
 


### PR DESCRIPTION
since the import was
`from testbook import testbook`
the decorator is simply `@testbook`