### PR TITLE
Revert "Using as decorator is a pytest fixture (#68)"

### DIFF
--- a/testbook/testbook.py
+++ b/testbook/testbook.py
@@ -1,11 +1,5 @@
 import nbformat
 
-try:
-    from pytest import fixture
-except ImportError:  # pragma: no cover
-    def fixture(func, *args, **kwargs):
-        return func
-
 from .client import TestbookNotebookClient
 
 
@@ -34,7 +28,7 @@ class testbook:
         self.client._cleanup_kernel()
 
     def __call__(self, func):
-        def wrapper(*args, **kwargs):  # pragma: no cover
+        def wrapper(*args, **kwargs):
             with self.client.setup_kernel():
                 self._prepare()
                 func(self.client, *args, **kwargs)
@@ -42,4 +36,4 @@ class testbook:
         wrapper.__name__ = func.__name__
         wrapper.__doc__ = func.__doc__
 
-        return fixture(wrapper)
+        return wrapper

--- a/testbook/tests/test_testbook.py
+++ b/testbook/tests/test_testbook.py
@@ -1,7 +1,4 @@
 import nbformat
-
-import pytest
-
 from ..testbook import testbook
 
 
@@ -19,17 +16,6 @@ def test_testbook_class_decorator(tb):
 @testbook('testbook/tests/resources/inject.ipynb')
 def test_testbook_class_decorator_execute_none(tb):
     assert tb.code_cells_executed == 0
-
-
-@testbook('testbook/tests/resources/inject.ipynb', execute=True)
-def test_testbook_decorator_with_fixture(nb, tmp_path):
-    assert True  # Check that the decorator accept to be passed along side a fixture
-
-
-@testbook('testbook/tests/resources/inject.ipynb', execute=True)
-@pytest.mark.parametrize("cell_index_args, expected_result", [(2, 2), ('hello', 1)])
-def test_testbook_decorator_with_markers(nb, cell_index_args, expected_result):
-    assert nb._cell_index(cell_index_args) == expected_result
 
 
 def test_testbook_execute_all_cells_context_manager():


### PR DESCRIPTION
This reverts commit 34cede054938fe361b10ac30a8d15e979abbb3e4.

Ref #75