### PR TITLE
Mimic patch for decorator and pytest fixtures

### DIFF
--- a/testbook/testbook.py
+++ b/testbook/testbook.py
@@ -8,7 +8,7 @@ from .client import TestbookNotebookClient
 
 class testbook:
     """`testbook` acts as function decorator or a context manager.
-    
+
     When the function/with statement exits the kernels started when
     entering the function/with statement will be terminated.
 
@@ -16,7 +16,7 @@ class testbook:
     will be passed as first argument to the decorated function.
     """
     # Developer notes:
-    # 
+    #
     # To trick pytest, we mimic the API of unittest.mock.patch in testbook.
     # Notably, the following elements are added:
     # * attribute_name, Class attribute (see below)

--- a/testbook/testbook.py
+++ b/testbook/testbook.py
@@ -1,15 +1,30 @@
-import nbformat
+import functools
+from unittest.mock import DEFAULT
 
-try:
-    from pytest import fixture
-except ImportError:  # pragma: no cover
-    def fixture(func, *args, **kwargs):
-        return func
+import nbformat
 
 from .client import TestbookNotebookClient
 
 
 class testbook:
+    """`testbook` acts as function decorator or a context manager.
+    
+    When the function/with statement exits the kernels started when
+    entering the function/with statement will be terminated.
+
+    If `testbook` is used as a decorator, the `TestbookNotebookClient`
+    will be passed as first argument to the decorated function.
+    """
+    # Developer notes:
+    # 
+    # To trick pytest, we mimic the API of unittest.mock.patch in testbook.
+    # Notably, the following elements are added:
+    # * attribute_name, Class attribute (see below)
+    # * new, Instance attribute (see __init__)
+    # * patchings, wrapper attributes (see __call__)
+
+    attribute_name = None
+
     def __init__(self, nb, execute=None, timeout=60, kernel_name='python3', allow_errors=False):
         self.execute = execute
         self.client = TestbookNotebookClient(
@@ -18,6 +33,8 @@ class testbook:
             allow_errors=allow_errors,
             kernel_name=kernel_name
         )
+
+        self.new = DEFAULT
 
     def _prepare(self):
         if self.execute is True:
@@ -34,12 +51,11 @@ class testbook:
         self.client._cleanup_kernel()
 
     def __call__(self, func):
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):  # pragma: no cover
             with self.client.setup_kernel():
                 self._prepare()
                 func(self.client, *args, **kwargs)
 
-        wrapper.__name__ = func.__name__
-        wrapper.__doc__ = func.__doc__
-
-        return fixture(wrapper)
+        wrapper.patchings = [self]
+        return wrapper

--- a/testbook/tests/test_testbook.py
+++ b/testbook/tests/test_testbook.py
@@ -32,6 +32,12 @@ def test_testbook_decorator_with_markers(nb, cell_index_args, expected_result):
     assert nb._cell_index(cell_index_args) == expected_result
 
 
+@pytest.mark.parametrize("cell_index_args, expected_result", [(2, 2), ('hello', 1)])
+@testbook('testbook/tests/resources/inject.ipynb', execute=True)
+def test_testbook_decorator_with_markers_order_does_not_matter(nb, cell_index_args, expected_result):
+    assert nb._cell_index(cell_index_args) == expected_result
+
+
 def test_testbook_execute_all_cells_context_manager():
     with testbook('testbook/tests/resources/inject.ipynb', execute=True) as tb:
         for cell in tb.cells[:-1]:


### PR DESCRIPTION
Fix #75

Edit: this is quite hacky. It may be better to use a third-party library (like [decorator](https://github.com/micheles/decorator)) to hack the function signature; actually this is where pytest fixture and a decorator get messy.