### PR TITLE
Passing kwargs to nbclient

### DIFF
--- a/testbook/testbook.py
+++ b/testbook/testbook.py
@@ -10,13 +10,14 @@ from .client import TestbookNotebookClient
 
 
 class testbook:
-    def __init__(self, nb, execute=None, timeout=60, kernel_name='python3', allow_errors=False):
+    def __init__(self, nb, execute=None, timeout=60, kernel_name='python3', allow_errors=False, **kwargs):
         self.execute = execute
         self.client = TestbookNotebookClient(
             nbformat.read(nb, as_version=4) if not isinstance(nb, nbformat.NotebookNode) else nb,
             timeout=timeout,
             allow_errors=allow_errors,
-            kernel_name=kernel_name
+            kernel_name=kernel_name,
+            **kwargs
         )
 
     def _prepare(self):


### PR DESCRIPTION
👋 
This PR passes `kwargs` down to nbclient. 
I want to be able to pass `resources` so I can specify the `cwd` in which a notebook is run. 


```python
def test_me():
    notebook = "folder/folder/nb.ipynb"
    p = str(pathlib.Path(notebook).parent.absolute())
    resources = {'metadata': {'path': p}}
    with testbook(notebook, execute=True, resources=resources) as nb:
        pass
```

thank you in advance