### PR TITLE
Added flag to avoid ignored execute requests in ipykernel 5.5

### DIFF
--- a/testbook/client.py
+++ b/testbook/client.py
@@ -21,7 +21,14 @@ from .utils import random_varname, all_subclasses
 
 
 class TestbookNotebookClient(NotebookClient):
+    __test__ = False
+
     def __init__(self, nb, km=None, **kw):
+        # Fix the ipykernel 5.5 issue where execute requests after errors are aborted
+        ea = kw.get('extra_arguments', [])
+        if not any(arg.startswith('--Kernel.stop_on_error_timeout') for arg in self.extra_arguments):
+            ea.append('--Kernel.stop_on_error_timeout=0')
+        kw['extra_arguments'] = ea
         super().__init__(nb, km=km, **kw)
 
     def ref(self, name: str) -> TestbookObjectReference:

--- a/testbook/exceptions.py
+++ b/testbook/exceptions.py
@@ -1,7 +1,6 @@
 class TestbookError(Exception):
     """Generic Testbook exception class"""
-
-    pass
+    __test__ = False
 
 
 class TestbookCellTagNotFoundError(TestbookError):
@@ -23,10 +22,12 @@ class TestbookExecuteResultNotFoundError(TestbookError):
 
 
 class TestbookAttributeError(AttributeError):
-    pass
+    __test__ = False
 
 
 class TestbookRuntimeError(RuntimeError):
+    __test__ = False
+
     def __init__(self, evalue, traceback, eclass=None):
         super().__init__(evalue)
         self.evalue = evalue


### PR DESCRIPTION
Fixes https://github.com/nteract/testbook/issues/88 by setting the flag causing https://github.com/ipython/ipykernel/issues/609 to 0 seconds, making failed JSONification requests not fail execute requests.

The change is a little coupled to ipykernel, so later on we may need to isolate the flag addition dependent on underlying kernel type.