### PR TITLE
Consider text/plain when calling notebook.cell_output_text(idx)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ coverage
 ipython
 ipykernel
 ipywidgets
-pandas==1.2.4
+pandas
 pytest>=4.1
 pytest-cov>=2.6.1
 check-manifest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ coverage
 ipython
 ipykernel
 ipywidgets
+pandas==1.2.4
 pytest>=4.1
 pytest-cov>=2.6.1
 check-manifest

--- a/testbook/client.py
+++ b/testbook/client.py
@@ -87,6 +87,8 @@ class TestbookNotebookClient(NotebookClient):
         for output in cell["outputs"]:
             if 'text' in output:
                 text += output['text']
+            elif "data" in output and "text/plain" in output["data"]:
+                text += output["data"]["text/plain"]
 
         return text.strip()
 

--- a/testbook/tests/resources/foo.ipynb
+++ b/testbook/tests/resources/foo.ipynb
@@ -50,6 +50,25 @@
    "source": [
     "foo()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "d = {'col1': [1, 2], 'col2': [3, 4]}\n",
+    "df = pd.DataFrame(data=d)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/testbook/tests/test_execute.py
+++ b/testbook/tests/test_execute.py
@@ -18,6 +18,13 @@ def test_execute_cell(notebook):
     assert notebook.cell_output_text(3) == 'foo'
 
 
+def test_execute_and_show_pandas_output(notebook):
+    notebook.execute_cell(4)
+    assert notebook.cell_output_text(4) == """col1  col2
+0     1     3
+1     2     4"""
+
+
 def test_execute_cell_tags(notebook):
     notebook.execute_cell('test1')
     assert notebook.cell_output_text('test1') == 'hello world\n[1, 2, 3]'


### PR DESCRIPTION
We have a use case where the cell output is some Pandas output and when
calling `notebook.cell_output_text(..)` we only get empty output, even
though `output["data"]["text/plain"]` contains actually the expected
text.